### PR TITLE
Adicionando timezone nos preços das unidades

### DIFF
--- a/src/Models/RealEstateDevelopment/Unit.php
+++ b/src/Models/RealEstateDevelopment/Unit.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use IntlTimeZone;
 
 /**
  * Class Unit.
@@ -24,7 +23,7 @@ class Unit extends BaseModel
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
-        $this->table = config('sp-produto.table_prefix') . 'units';
+        $this->table = config('sp-produto.table_prefix').'units';
     }
 
     /**
@@ -151,7 +150,7 @@ class Unit extends BaseModel
     public function tablePrice(): Attribute
     {
         return Attribute::get(function () {
-            $period = now("America/Sao_Paulo")->format('Y-m-01');
+            $period = now('America/Sao_Paulo')->format('Y-m-01');
             $price = $this->prices()->where('period', $period)->value('table_price');
 
             return $price ?? '0.00';
@@ -161,7 +160,7 @@ class Unit extends BaseModel
     public function fixedPrice(): Attribute
     {
         return Attribute::get(function () {
-            $period = now("America/Sao_Paulo")->format('Y-m-01');
+            $period = now('America/Sao_Paulo')->format('Y-m-01');
             $price = $this->prices()->where('period', $period)->value('fixed_price');
 
             return $price ?? '0.00';
@@ -171,7 +170,7 @@ class Unit extends BaseModel
     public function hasPriceTablePeriod(): Attribute
     {
         return Attribute::get(function () {
-            $period = now("America/Sao_Paulo")->format('Y-m-01');
+            $period = now('America/Sao_Paulo')->format('Y-m-01');
 
             return $this->prices()->where('period', $period)->exists();
         });

--- a/src/Models/RealEstateDevelopment/Unit.php
+++ b/src/Models/RealEstateDevelopment/Unit.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use IntlTimeZone;
 
 /**
  * Class Unit.
@@ -23,7 +24,7 @@ class Unit extends BaseModel
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
-        $this->table = config('sp-produto.table_prefix').'units';
+        $this->table = config('sp-produto.table_prefix') . 'units';
     }
 
     /**
@@ -150,35 +151,27 @@ class Unit extends BaseModel
     public function tablePrice(): Attribute
     {
         return Attribute::get(function () {
-            $period = date('Y-m-01');
-            $query = $this->prices()->where('period', $period);
+            $period = now("America/Sao_Paulo")->format('Y-m-01');
+            $price = $this->prices()->where('period', $period)->value('table_price');
 
-            if ($query->exists()) {
-                return $query->first()->table_price;
-            }
-
-            return '0.00';
+            return $price ?? '0.00';
         });
     }
 
     public function fixedPrice(): Attribute
     {
         return Attribute::get(function () {
-            $period = date('Y-m-01');
-            $query = $this->prices()->where('period', $period);
+            $period = now("America/Sao_Paulo")->format('Y-m-01');
+            $price = $this->prices()->where('period', $period)->value('fixed_price');
 
-            if ($query->exists()) {
-                return $query->first()->fixed_price;
-            }
-
-            return '0.00';
+            return $price ?? '0.00';
         });
     }
 
     public function hasPriceTablePeriod(): Attribute
     {
         return Attribute::get(function () {
-            $period = date('Y-m-01');
+            $period = now("America/Sao_Paulo")->format('Y-m-01');
 
             return $this->prices()->where('period', $period)->exists();
         });


### PR DESCRIPTION
Esse PR é para um problema encontrado quando é utilizado a nova tabela de preço das unidades.

Como todo nosso banco e servidores estão com UTC-0, porém trabalhamos em um território que está a UTC-3, quando chegasse a 21:00 do dia 31/10 todas as vendas de unidades seriam bloqueadas, pois o nosso servidor estará em 00:00 do dia 01/11. 

O código utilizado é temporário, apenas para resolver esse problema enquanto não encontramos uma solução mais dinâmica e definitiva para esse e outros problemas envolvendo TZ.