### PR TITLE
Corrigindo a atribuição de hub_company_real_estate_agency_id para usar UUID diretamente

### DIFF
--- a/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
+++ b/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
@@ -76,7 +76,7 @@ trait RealEstateDevelopmentHelper
             $realEstateDevelopment = new RealEstateDevelopment;
             $realEstateDevelopment->uuid = $message->uuid;
             $realEstateDevelopment->hub_company_id = $this->getHubCompanyId($message->hub_company_uuid);
-            $realEstateDevelopment->hub_company_real_estate_agency_id = $this->getHubCompanyId($message->hub_company_real_estate_agency->uuid);
+            $realEstateDevelopment->hub_company_real_estate_agency_id = $this->getHubCompanyId($message->hub_company_real_estate_agency_uuid);
             $realEstateDevelopment->save();
         }
 
@@ -207,7 +207,7 @@ trait RealEstateDevelopmentHelper
         }
 
         $realEstateDevelopment->hub_company_id = $this->getHubCompanyId($message->hub_company_uuid);
-        $realEstateDevelopment->hub_company_real_estate_agency_id = $this->getHubCompanyId($message->hub_company_real_estate_agency->uuid);
+        $realEstateDevelopment->hub_company_real_estate_agency_id = $this->getHubCompanyId($message->hub_company_real_estate_agency_uuid);
 
         $realEstateDevelopment->save();
     }


### PR DESCRIPTION
Esta solicitação de pull atualiza a classe `RealEstateDevelopmentHelper` para corrigir um bug relacionado ao acesso à propriedade `hub_company_real_estate_agency`. As alterações garantem que a propriedade correta, `hub_company_real_estate_agency_uuid`, seja usada ao recuperar o ID da agência.

Correção de bug em `RealEstateDevelopmentHelper`:

* [`src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php`](diffhunk://#diff-942284188cc348d2502eb3bd9e170760f6fba26be22052a35fd71e487a47dfe3L79-R79): Dois métodos, `getRealEstateDevelopment` e `realEstateDevelopment`, foram atualizados para substituir a propriedade incorreta `$message->hub_company_real_estate_agency->uuid` por `$message->hub_company_real_estate_agency_uuid` ao chamar `getHubCompanyId`. Isso garante o tratamento adequado do campo `hub_company_real_estate_agency_uuid`. [[1]](diffhunk://#diff-942284188cc348d2502eb3bd9e170760f6fba26be22052a35fd71e487a47dfe3L79-R79) [[2]](diffhunk://#diff-942284188cc348d2502eb3bd9e170760f6fba26be22052a35fd71e487a47dfe3L210-R210)