### PR TITLE
Ajustando campo nulo na função getBrandId

### DIFF
--- a/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
+++ b/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
@@ -218,10 +218,10 @@ trait RealEstateDevelopmentHelper
 
     private function getBrandId(?string $hubBrandUuid): ?int
     {
-        if (!$hubBrandUuid) {
+        if (! $hubBrandUuid) {
             return null;
         }
-        
+
         return HubBrand::withTrashed()
             ->where('uuid', $hubBrandUuid)
             ->first()
@@ -232,8 +232,7 @@ trait RealEstateDevelopmentHelper
     {
         $hubCompany = HubCompany::withTrashed()
             ->where('uuid', $hubCompanyUuid)
-            ->first();
-
-        return $hubCompany->id;
+            ->first()
+            ->id;
     }
 }

--- a/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
+++ b/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
@@ -216,13 +216,16 @@ trait RealEstateDevelopmentHelper
         $realEstateDevelopment->save();
     }
 
-    private function getBrandId(string $hubBrandUuid): int
+    private function getBrandId(?string $hubBrandUuid): ?int
     {
-        $hubBrand = HubBrand::withTrashed()
+        if (!$hubBrandUuid) {
+            return null;
+        }
+        
+        return HubBrand::withTrashed()
             ->where('uuid', $hubBrandUuid)
-            ->first();
-
-        return $hubBrand?->id;
+            ->first()
+            ?->id;
     }
 
     private function getHubCompanyId(string $hubCompanyUuid): int


### PR DESCRIPTION
Este pull request atualiza os métodos `getBrandId` e `getHubCompanyId` na classe `RealEstateDevelopmentHelper` para melhorar a segurança contra nulos e simplificar o código.

### Melhorias na Segurança contra Nulos:
* Método `getBrandId`: Atualizado para aceitar um parâmetro `hubBrandUuid` anulável e retornar um inteiro anulável. Adicionada uma verificação de nulos para `hubBrandUuid` para evitar consultas desnecessárias ao banco de dados quando o parâmetro for nulo.

### Simplificação do Código:
* Método `getHubCompanyId`: Simplificou a instrução return encadeando a propriedade `id` diretamente após a chamada do método `first()`.