### PR TITLE
Adicionar campo de tipo de endereço de construção no modelo de Desenvolvimento Imobiliário

### DIFF
--- a/database/migrations/add_construction_address_type_on_real_estate_developments_table.php.stub
+++ b/database/migrations/add_construction_address_type_on_real_estate_developments_table.php.stub
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private string $tableName;
+
+    public function __construct()
+    {
+        $this->tableName = config('sp-produto.table_prefix') . 'real_estate_developments';
+    }
+
+    public function up()
+    {
+        if (Schema::hasTable($this->tableName)) {
+            Schema::table($this->tableName, function (Blueprint $table) {
+                $table->string('construction_address_type')->nullable();
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasTable($this->tableName)) {
+            Schema::table($this->tableName, function (Blueprint $table) {
+                $table->dropColumn('construction_address_type');
+            });
+        }
+    }
+};

--- a/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
+++ b/src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php
@@ -101,6 +101,9 @@ trait RealEstateDevelopmentHelper
         if (property_exists($message, 'construction_address')) {
             $realEstateDevelopment->construction_address = $message->construction_address;
         }
+        if (property_exists($message, 'construction_address_type')) {
+            $realEstateDevelopment->construction_address_type = $message->construction_address_type;
+        }
         if (property_exists($message, 'construction_city')) {
             $realEstateDevelopment->construction_city = $message->construction_city;
         }

--- a/src/Enums/StreetType.php
+++ b/src/Enums/StreetType.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace BildVitta\SpProduto\Enums;
+
+use BildVitta\SpProduto\Traits\EnumHelper;
+
+enum StreetType: string
+{
+    use EnumHelper;
+
+    case STREET = 'street'; // Rua
+    case AVENUE = 'avenue'; // Avenida
+    case ALLEY = 'alley'; // Alameda
+    case ROAD = 'road'; // Estrada
+    case PLAZA = 'plaza'; // Praça
+    case HIGHWAY = 'highway'; // Rodovia
+    case LANE = 'lane'; // Travessa
+
+    //    case AIRPORT = 'airport'; // Aeroporto
+    //    case AREA = 'area'; // Área
+    //    case FARMHOUSE = 'farmhouse'; // Chácara
+    //    case COLONY = 'colony'; // Colônia
+    //    case CONDOMINIUM = 'condominium'; // Condomínio
+    //    case COMPLEX = 'complex'; // Conjunto
+    //    case DISTRICT = 'district'; // Distrito
+    //    case ESPLANADE = 'esplanade'; // Esplanada
+    //    case STATION = 'station'; // Estação
+    //    case SLUM = 'slum'; // Favela
+    //    case FARM = 'farm'; // Fazenda
+    //    case FAIR = 'fair'; // Feira
+    //    case GARDEN = 'garden'; // Jardim
+    //    case SLOPE = 'slope'; // Ladeira
+    //    case LAKE = 'lake'; // Lago
+    //    case LAGOON = 'lagoon'; // Lagoa
+    //    case SQUARE = 'square'; // Largo
+    //    case HOUSING = 'housing'; // Loteamento
+    //    case HILL = 'hill'; // Morro
+    //    case CORE = 'core'; // Núcleo
+    //    case PARK = 'park'; // Parque
+    //    case CATWALK = 'catwalk'; // Passarela
+    //    case COURTYARD = 'courtyard'; // Pátio
+    //    case BLOCK = 'block'; // Quadra
+    //    case REFUGE = 'refuge'; // Recanto
+    //    case RESIDENTIAL = 'residential'; // Residencial
+    //    case SECTOR = 'sector'; // Setor
+    //    case RANCH = 'ranch'; // Sítio
+    //    case SECTION = 'section'; // Trecho
+    //    case ROUNDABOUT = 'roundabout'; // Trevo
+    //    case WAY = 'way'; // Via
+    //    case OVERPASS = 'overpass'; // Viaduto
+    //    case ALLEYWAY = 'alleyway'; // Viela
+    //    case VILLAGE = 'village'; // Vila
+
+    // Método para retornar o nome do logradouro em português
+    public function getName(): string
+    {
+        return __($this->value);
+    }
+
+    /**
+     * Get the label for each account type.
+     */
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::STREET => __('street'),
+            self::AVENUE => __('avenue'),
+            self::ALLEY => __('alley'),
+            self::ROAD => __('road'),
+            self::PLAZA => __('plaza'),
+            self::HIGHWAY => __('highway'),
+            self::LANE => __('lane'),
+        };
+    }
+}

--- a/src/Models/RealEstateDevelopment.php
+++ b/src/Models/RealEstateDevelopment.php
@@ -45,6 +45,7 @@ class RealEstateDevelopment extends BaseModel
         'address',
         'city',
         'complement',
+        'construction_address_type',
         'construction_address',
         'construction_city',
         'construction_complement',

--- a/src/SpProdutoServiceProvider.php
+++ b/src/SpProdutoServiceProvider.php
@@ -81,6 +81,7 @@ class SpProdutoServiceProvider extends PackageServiceProvider
         'add_segment_field_on_real_estate_developments_table',
         'add_hub_company_real_estate_agency_id_on_real_estate_developments_table',
         'add_brand_id_on_real_estate_developments_table',
+        'add_construction_address_type_on_real_estate_developments_table',
         'alter_table_typology_attributes_table',
     ];
 
@@ -131,6 +132,7 @@ class SpProdutoServiceProvider extends PackageServiceProvider
             'add_segment_field_on_real_estate_developments_table',
             'add_hub_company_real_estate_agency_id_on_real_estate_developments_table',
             'add_brand_id_on_real_estate_developments_table',
+            'add_construction_address_type_on_real_estate_developments_table',
         ];
         foreach ($relations as $relation) {
             switch ($relation) {

--- a/src/Traits/EnumHelper.php
+++ b/src/Traits/EnumHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BildVitta\SpProduto\Traits;
+
+trait EnumHelper
+{
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function keys(): array
+    {
+        return array_column(self::cases(), 'name');
+    }
+
+    public static function keyValue(): array
+    {
+        $cases = self::cases();
+        $keyValuePairs = [];
+        foreach ($cases as $case) {
+            $keyValuePairs[$case->name] = $case->getLabel();
+        }
+
+        return $keyValuePairs;
+    }
+
+    /**
+     * Get all account types as an array.
+     */
+    public static function toArray(): array
+    {
+        return self::values();
+    }
+
+    /**
+     * Get options for a select input.
+     */
+    public static function toSelectOptions(): array
+    {
+        return array_map(
+            fn (self $type) => [
+                'label' => $type->getLabel(),
+                'value' => $type->value,
+            ],
+            self::cases()
+        );
+    }
+
+    public static function optionsWithParameters(array $options): array
+    {
+        return collect($options)->map(fn (string $option) => [
+            'value' => $option,
+            'label' => self::getLabelWithParameter($option),
+        ])
+            ->toArray();
+    }
+
+    public static function getLabelWithParameter(string $value): ?string
+    {
+        $name = collect(self::cases())->firstWhere('value', $value)?->name;
+
+        return __($name);
+    }
+}


### PR DESCRIPTION
Este pull request introduz um novo campo `construction_address_type` à tabela `real_estate_developments`, adiciona lógica de suporte para lidar com esse campo e implementa uma nova enumeração `StreetType` com métodos auxiliares. Abaixo estão as alterações mais importantes agrupadas por tema:

### Alterações no Banco de Dados:
* Adicionado um arquivo de migração para introduzir a coluna `construction_address_type` à tabela `real_estate_developments`, com suporte para adicionar e remover a coluna. (`database/migrations/add_construction_address_type_on_real_estate_developments_table.php.stub`)

### Atualizações de Modelo e Atributos:
* Atualizado o modelo `RealEstateDevelopment` para incluir `construction_address_type` em sua lista de atributos preenchíveis. (`src/Models/RealEstateDevelopment.php`)

### Melhorias em Enum e Helper:
* Criada uma nova enumeração `StreetType` com tipos de rua predefinidos (por exemplo, `STREET`, `AVENUE`, `ALLEY`) e métodos auxiliares para recuperar nomes, rótulos e outros metadados. (`src/Enums/StreetType.php`)
* Adicionada a característica `EnumHelper` para fornecer métodos utilitários para enumerações, como recuperar valores, chaves e gerar opções de seleção. (`src/Traits/EnumHelper.php`)

### Atualizações de Comandos e Provedores de Serviços:
* Aprimorada a propriedade `RealEstateDevelopmentHelper` para mapear a propriedade `construction_address_type` de mensagens para o modelo `RealEstateDevelopment`. (`src/Console/Commands/Messages/Resources/Helpers/RealEstateDevelopmentHelper.php`)
* A nova migração foi registrada no `SpProdutoServiceProvider` para garantir que ela seja incluída durante a execução da migração. (`src/SpProdutoServiceProvider.php`) [[1]](diffhunk://#diff-18ba1a94d9a390a9a157cf95ef7d6b8dba5ee335887376e1eccffccb477bad15R84) [[2]](diffhunk://#diff-18ba1a94d9a390a9a157cf95ef7d6b8dba5ee335887376e1eccffccb477bad15R135)